### PR TITLE
Docker化のための手順を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:3.2.2
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libpq-dev \
+    nodejs \
+    yarn
+WORKDIR /myapp
+COPY Gemfile Gemfile.lock /myapp/
+RUN bundle install

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# README
+# 環境構築方法
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## 1. GitHubリポジトリURLを自身のPCにクローン
+```zsh
+git cline git@github.com:chika-bac/rails-docker.git
 
-Things you may want to cover:
+# クローンしたリポジトリに移動
+cd rails-docker
+```
 
-* Ruby version
+## 2. 以下コマンドを実施してコンテナを起動
+```zsh
+docker-compose up
+```
 
-* System dependencies
+## 3. コンテナ内にDBを作成
+ターミナルの別タブを開き、以下コマンドを実行
+```zsh
+docker compose exec web rails db:create
+docker compose exec web rails db:migrate
+```
 
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## 4. ブラウザで動作確認
+`http:localhost:3000`にアクセスし、表示確認をする

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,11 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  host: db
+  user: postgres
+  port: 5432
+  password: <%= ENV.fetch("POSTGRES_PASSWORD") %>
+
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3'
+volumes:
+  db-data:
+
+services:
+  web:
+    build: .
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    ports:
+      - "3000:3000"
+    volumes:
+      - ".:/myapp"
+    environment:
+      - "POSTGRES_PASSWORD=postgres"
+    tty: true
+    stdin_open: true
+    depends_on:
+      - db
+
+  db:
+    image: postgres:12
+    volumes:
+      - "db-data:/var/lib/postgresql/data"
+    environment:
+      - "POSTGRES_PASSWORD=postgres"


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/07_docker/003_docker.md

## やったこと

* 以下のプロジェクトのDocker化と、環境構築手順の追加
* https://github.com/ihatov08/rails7_docker_template

## 動作確認方法

* README.mdの手順でDocker化して、ブラウザで動作確認

## その他

* `docker-compose up`したログ
```
rails-docker-db-1   | 
rails-docker-db-1   | PostgreSQL Database directory appears to contain a database; Skipping initialization
rails-docker-db-1   | 
rails-docker-db-1   | 2024-01-03 11:21:33.066 UTC [1] LOG:  starting PostgreSQL 12.17 (Debian 12.17-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
rails-docker-db-1   | 2024-01-03 11:21:33.066 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
rails-docker-db-1   | 2024-01-03 11:21:33.066 UTC [1] LOG:  listening on IPv6 address "::", port 5432
rails-docker-db-1   | 2024-01-03 11:21:33.071 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
rails-docker-db-1   | 2024-01-03 11:21:33.090 UTC [27] LOG:  database system was shut down at 2024-01-03 11:21:24 UTC
rails-docker-db-1   | 2024-01-03 11:21:33.103 UTC [1] LOG:  database system is ready to accept connections
rails-docker-web-1  | => Booting Puma
rails-docker-web-1  | => Rails 7.0.6 application starting in development 
rails-docker-web-1  | => Run `bin/rails server --help` for more startup options
rails-docker-web-1  | Puma starting in single mode...
rails-docker-web-1  | * Puma version: 5.6.6 (ruby 3.2.2-p53) ("Birdie's Version")
rails-docker-web-1  | *  Min threads: 5
rails-docker-web-1  | *  Max threads: 5
rails-docker-web-1  | *  Environment: development
rails-docker-web-1  | *          PID: 1
rails-docker-web-1  | * Listening on http://0.0.0.0:3000
rails-docker-web-1  | Use Ctrl-C to stop
```

* http://localhost:3000/ にアクセスした際のキャプチャ
![docker-railsキャプチャ](https://github.com/chika-bac/rails-docker/assets/153085075/b2cb9c59-c398-4dc9-abdc-1d1def3855a8)